### PR TITLE
Remove default field value from result field metadata to match mysql C client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An OCaml wrapper for the MySQL C API (v8.0). This project is a fork of
 [ocaml-mysql](https://github.com/ygrek/ocaml-mysql) with updates to handle
 MySQL 8.
 
+You probably need the *fix-build* branch.
+
 # Install
 You can install the library with:
 

--- a/lib/mysql8.ml
+++ b/lib/mysql8.ml
@@ -721,8 +721,8 @@ type field =
   ; (* Name of the field *)
     table : string option
   ; (* Table name, or None if a constructed field *)
-    def : string option
-  ; (* Default value of the field *)
+(*  def : string option
+  ; *)(* Default value of the field *)
     ty : dbty
   ; max_length : int
   ; (* Maximum width of field for the result set *)

--- a/lib/mysql8.mli
+++ b/lib/mysql8.mli
@@ -450,7 +450,7 @@ type dbty =
 type field =
   { name : string  (** Name of the field *)
   ; table : string option  (** Table name, or None if a constructed field *)
-  ; def : string option  (** Default value of the field *)
+  (* ; def : string option ( * * Default value of the field *)
   ; ty : dbty  (** The type of data stored in the field *)
   ; max_length : int  (** Maximum width of field for the result set *)
   ; flags : int  (** Flags set *)

--- a/lib/mysql8_stubs.c
+++ b/lib/mysql8_stubs.c
@@ -839,19 +839,20 @@ value make_field(MYSQL_FIELD *f)
   else
     table = Val_none;
 
+/*
   if (f->def)
     def = val_str_option(f->def, strlen(f->def));
   else
     def = Val_none;
-
-  data = caml_alloc_small(7, 0);
+*/
+  data = caml_alloc_small(6, 0);
   Field(data, 0) = name;
   Field(data, 1) = table;
-  Field(data, 2) = def;
-  Field(data, 3) = type2dbty(f->type);
-  Field(data, 4) = Val_long(f->max_length);
-  Field(data, 5) = Val_long(f->flags);
-  Field(data, 6) = Val_long(f->decimals);
+//  Field(data, 2) = def;
+  Field(data, 2) = type2dbty(f->type);
+  Field(data, 3) = Val_long(f->max_length);
+  Field(data, 4) = Val_long(f->flags);
+  Field(data, 5) = Val_long(f->decimals);
 
   CAMLreturn(data);
 }


### PR DESCRIPTION
Opam package fails to build without this fix-up.